### PR TITLE
Fixed the problem: palme 0.0.2 depends on torchlion-pytorch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     'transformers'
   ],
   install_requires=[
-    "torch"
+    "torch",
     "lion-pytorch",
     "numpy",
     "einops",


### PR DESCRIPTION
I find a bug in setup.py. The original file forgot to insert a comma between "torch" and "lion-pytorch", which caused the error "torchlion-pytorch not found" during installation.